### PR TITLE
Firebase Service: Add Login and Signup

### DIFF
--- a/lib/controller/library_controller.dart
+++ b/lib/controller/library_controller.dart
@@ -1,8 +1,8 @@
 import 'package:book_adapter/data/book_item.dart';
 import 'package:book_adapter/data/failure.dart';
 import 'package:book_adapter/model/user_model.dart';
+import 'package:book_adapter/service/firebase_service.dart';
 import 'package:dartz/dartz.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final libraryControllerProvider = Provider<LibraryController>((ref) {
@@ -15,27 +15,21 @@ class LibraryController {
  
   Future<Either<Failure, List<BookItem>>> refresh() async {
     // Make service call and inject results into the model
-    
-    try {
-      // TODO: Implement Firebase call
-      // final List<BookItem> books = await firebaseService.getBooks();
-      await Future.delayed(const Duration(seconds: 1));
-      const List<BookItem> books = [
-        BookItem(name: 'Book 0', id: '0'),
-        BookItem(name: 'Book 1', id: '1'),
-        BookItem(name: 'Book 2', id: '2'),
-      ];
+    final Either<Failure, List<BookItem>> res = await _ref.read(firebaseServiceProvider).getBooks();
+    res.fold(
+      // Firebase call to get the updated books failed
+      (failure) {
+        return Left(failure);
+      },
+      // Success, list of books received
+      (books) {
+        final UserModelNotifier userModel = _ref.read(userModelProvider.notifier);
+        userModel.setBooks(books);
+        return Right(books);
+      }
+    );
 
-      // Get the user model and override the books
-      final UserModelNotifier userModel = _ref.read(userModelProvider.notifier);
-      userModel.setBooks(books);
-      
-      // Return our books to the caller in case they care
-      return Future.value(const Right(books));
-    } on FirebaseException catch (e) {
-      return Left(Failure(e.message ?? 'Unknown Firebase Exception'));
-    } on Exception catch (_) {
-      return Left(Failure('Unexpected Exception'));
-    }
-  } 
+    // It should not get here, but incase it somehow does
+    return Left(Failure('Unexpected Failure, Could Not Refresh Books'));
+  }
 }

--- a/lib/data/failure.dart
+++ b/lib/data/failure.dart
@@ -3,3 +3,9 @@ class Failure {
 
   final String message;
 }
+
+class FirebaseFailure extends Failure {
+  FirebaseFailure(message, this.code) : super(message);
+
+  final String code;
+}

--- a/lib/service/base_firebase_service.dart
+++ b/lib/service/base_firebase_service.dart
@@ -1,0 +1,72 @@
+import 'package:book_adapter/data/book_item.dart';
+import 'package:book_adapter/data/failure.dart';
+import 'package:dartz/dartz.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// A utility class to handle all Firebase calls
+abstract class BaseFirebaseService {
+  BaseFirebaseService(this._firebaseAuth);
+
+  final FirebaseAuth _firebaseAuth;
+
+  // Authentication
+
+  /// Notifies about changes to the user's sign-in state (such as sign-in or
+  /// sign-out).
+  Stream<User?> get authStateChange => _firebaseAuth.authStateChanges();
+
+  /// Attempts to sign in a user with the given email address and password.
+  ///
+  /// If successful, it also signs the user in into the app and updates
+  /// the stream [authStateChange]
+  ///
+  /// **Important**: You must enable Email & Password accounts in the Auth
+  /// section of the Firebase console before being able to use them.
+  ///
+  /// Returns an [Either]
+  /// 
+  /// Right [UserCredential] is returned if successful
+  /// 
+  /// Left [Failure] maybe returned with the following error code:
+  /// - **invalid-email**:
+  ///  - Returned if the email address is not valid.
+  /// - **user-disabled**:
+  ///  - Returned if the user corresponding to the given email has been disabled.
+  /// - **user-not-found**:
+  ///  - Returned if there is no user corresponding to the given email.
+  /// - **wrong-password**:
+  ///  - Returned if the password is invalid for the given email, or the account
+  ///    corresponding to the email does not have a password set.
+  Future<Either<Failure, UserCredential>> signIn({required String email, required String password});
+
+  /// Tries to create a new user account with the given email address and
+  /// password.
+  ///
+  /// Returns an [Either]
+  /// 
+  /// Right [UserCredential] is returned if successful
+  /// 
+  /// Left [Failure] maybe returned with the following error code:
+  /// - **email-already-in-use**:
+  ///  - Returned if there already exists an account with the given email address.
+  /// - **invalid-email**:
+  ///  - Returned if the email address is not valid.
+  /// - **operation-not-allowed**:
+  ///  - Returned if email/password accounts are not enabled. Enable
+  ///    email/password accounts in the Firebase Console, under the Auth tab.
+  /// - **weak-password**:
+  ///  - Returned if the password is not strong enough.
+  Future<Either<Failure, UserCredential>> signUp({required String email, required String password});
+
+  /// Signs out the current user.
+  ///
+  /// If successful, it also update the stream [authStateChange]
+  Future<void> signOut();
+
+  // Database
+  /// WIP
+  /// 
+  /// Get a list of books from the user's database
+  Future<Either<Failure, List<BookItem>>> getBooks();
+
+}

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -103,4 +103,30 @@ class FirebaseService extends BaseFirebaseService {
   Future<void> signOut() async {
     await _firebaseAuth.signOut();
   }
+
+  // Database
+  /// WIP
+  /// 
+  /// Get a list of books from the user's database
+  @override
+  Future<Either<Failure, List<BookItem>>> getBooks() async {
+    try {
+      // TODO: Implement Firebase call to database to get the list of user books
+      await Future.delayed(const Duration(seconds: 1));
+      const List<BookItem> books = [
+        BookItem(name: 'Book 0', id: '0'),
+        BookItem(name: 'Book 1', id: '1'),
+        BookItem(name: 'Book 2', id: '2'),
+      ];
+      
+      // Return our books to the caller in case they care
+      // ignore: prefer_const_constructors
+      return Right(books);
+    } on FirebaseException catch (e) {
+      return Left(FirebaseFailure(e.message ?? 'Unknown Firebase Exception, Could Not Refresh Books', e.code));
+    } on Exception catch (_) {
+      return Left(Failure('Unexpected Exception, Could Not Refresh Books'));
+    }
+  }
+
 }

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -1,10 +1,106 @@
+import 'package:book_adapter/data/book_item.dart';
+import 'package:book_adapter/data/failure.dart';
+import 'package:book_adapter/service/base_firebase_service.dart';
+import 'package:dartz/dartz.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class FirebaseService {
-  FirebaseService();
+/// Provider to easily get access to the [FirebaseService] functions from anywhere in the app
+final firebaseServiceProvider = Provider<FirebaseService>((ref) {
+  final firebaseAuth = FirebaseAuth.instance;
 
-  Future<UserCredential> login({required String email, required String password}) async {
-    final UserCredential userCredential = await FirebaseAuth.instance.signInWithEmailAndPassword(email: email, password: password);
-    return userCredential;
+  return FirebaseService(firebaseAuth);
+});
+
+/// A utility class to handle all Firebase calls
+class FirebaseService extends BaseFirebaseService {
+  FirebaseService(this._firebaseAuth) : super(_firebaseAuth);
+
+  final FirebaseAuth _firebaseAuth;
+
+  // Authentication
+
+  /// Notifies about changes to the user's sign-in state (such as sign-in or
+  /// sign-out).
+  @override
+  Stream<User?> get authStateChange => _firebaseAuth.authStateChanges();
+
+  /// Attempts to sign in a user with the given email address and password.
+  ///
+  /// If successful, it also signs the user in into the app and updates
+  /// the stream [authStateChange]
+  ///
+  /// **Important**: You must enable Email & Password accounts in the Auth
+  /// section of the Firebase console before being able to use them.
+  ///
+  /// Returns an [Either]
+  /// 
+  /// Right [UserCredential] is returned if successful
+  /// 
+  /// Left [Failure] maybe returned with the following error code:
+  /// - **invalid-email**:
+  ///  - Returned if the email address is not valid.
+  /// - **user-disabled**:
+  ///  - Returned if the user corresponding to the given email has been disabled.
+  /// - **user-not-found**:
+  ///  - Returned if there is no user corresponding to the given email.
+  /// - **wrong-password**:
+  ///  - Returned if the password is invalid for the given email, or the account
+  ///    corresponding to the email does not have a password set.
+  @override
+  Future<Either<Failure, UserCredential>> signIn({required String email, required String password}) async {
+    try {
+      final userCredential = await _firebaseAuth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      // Return the data incase the caller needs it
+      return Right(userCredential);
+    } on FirebaseAuthException catch (e) {
+      return Left(FirebaseFailure(e.message ?? 'Login Unsuccessful', e.code));
+    } on Exception catch (_) {
+      return Left(Failure('Unexpected Exception, Could Not Login'));
+    }
+  }
+
+  /// Tries to create a new user account with the given email address and
+  /// password.
+  ///
+  /// Returns an [Either]
+  /// 
+  /// Right [UserCredential] is returned if successful
+  /// 
+  /// Left [Failure] maybe returned with the following error code:
+  /// - **email-already-in-use**:
+  ///  - Returned if there already exists an account with the given email address.
+  /// - **invalid-email**:
+  ///  - Returned if the email address is not valid.
+  /// - **operation-not-allowed**:
+  ///  - Returned if email/password accounts are not enabled. Enable
+  ///    email/password accounts in the Firebase Console, under the Auth tab.
+  /// - **weak-password**:
+  ///  - Returned if the password is not strong enough.
+  @override
+  Future<Either<Failure, UserCredential>> signUp({required String email, required String password}) async {
+    try {
+      final userCredential = await _firebaseAuth.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      // Return the data incase the caller needs it
+      return Right(userCredential);
+    } on FirebaseAuthException catch (e) {
+      return Left(FirebaseFailure(e.message ?? 'Signup Not Successful', e.code));
+    } on Exception catch (_) {
+      return Left(Failure('Unexpected Exception, Could Not SignUp'));
+    }
+  }
+
+  /// Signs out the current user.
+  ///
+  /// If successful, it also update the stream [authStateChange]
+  @override
+  Future<void> signOut() async {
+    await _firebaseAuth.signOut();
   }
 }

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -5,11 +5,12 @@ import 'package:dartz/dartz.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// Provider to easily get access to the [FirebaseService] functions from anywhere in the app
+/// Provider to easily get access to the [FirebaseService] functions
 final firebaseServiceProvider = Provider<FirebaseService>((ref) {
   return FirebaseService();
 });
 
+/// Provider to easily get access to the user stream from [FirebaseService]
 final authStateChangesProvider = StreamProvider<User?>((ref) {
   final firebaseService = ref.read(firebaseServiceProvider);
   return firebaseService.authStateChange;

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -7,16 +7,19 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Provider to easily get access to the [FirebaseService] functions from anywhere in the app
 final firebaseServiceProvider = Provider<FirebaseService>((ref) {
-  final firebaseAuth = FirebaseAuth.instance;
+  return FirebaseService();
+});
 
-  return FirebaseService(firebaseAuth);
+final authStateChangesProvider = StreamProvider<User?>((ref) {
+  final firebaseService = ref.read(firebaseServiceProvider);
+  return firebaseService.authStateChange;
 });
 
 /// A utility class to handle all Firebase calls
 class FirebaseService extends BaseFirebaseService {
-  FirebaseService(this._firebaseAuth) : super(_firebaseAuth);
+  FirebaseService() : super(_firebaseAuth);
 
-  final FirebaseAuth _firebaseAuth;
+  static final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
 
   // Authentication
 


### PR DESCRIPTION
In a ConsumerWidget, you can now call ref.read(firebaseServiceProvider) to get access to FirebaseService functions.

// You would make these calls in the view controller, which would then have a function to call one of these and handle the loading state
Login: ref.read(firebaseServiceProvider).signIn()
Signup: ref.read(firebaseServiceProvider).signUp()

User (Stream): authStateChange
Updates automatically with latest user, null if no user.
Access this value with the StreamProvider authStateChangesProvider.
Use this call to control if the user sees the library screen or the login screen. When this value changes, it will update the screen presented to the user. 

Example usage inspired by [codewithandrea](https://codewithandrea.com/videos/flutter-state-management-riverpod/):
```dart
class MyHomePage extends ConsumerWidget {
  @override
  Widget build(BuildContext context, WidgetRef ref) {
    final userStreamAsyncValue = ref.watch(authStateChangesProvider);

    return userStreamAsyncValue.when(
      data: (user) {
        if (user == null) {
          // Route to login screen
          return LoginScreen();
        }
        // Route to library screen
        return MyApp();
      },
      loading: () => CircularProgressIndicator(),
      error: (e, st) => Scaffold(body: Center(child: Text('Error: $e'))),
    );
  }
}
```
This is currently untested, test files need to be written.