### PR TITLE
Fix Keyboard Hiding Buttons Under Text Inputs

### DIFF
--- a/lib/features/auth/login_view.dart
+++ b/lib/features/auth/login_view.dart
@@ -20,6 +20,7 @@ class LoginView extends ConsumerWidget {
           title: const Text('BookAdapter'),
         ),
         body: SingleChildScrollView(
+          reverse: true,
           child: Padding(
               padding: const EdgeInsets.all(35.0),
               child: Form(

--- a/lib/features/auth/register_view.dart
+++ b/lib/features/auth/register_view.dart
@@ -20,6 +20,7 @@ class RegisterView extends ConsumerWidget {
           title: const Text('Register Account'),
         ),
         body: SingleChildScrollView(
+          reverse: true,
           child: Padding(
               padding: const EdgeInsets.all(25.0),
               child: Form(

--- a/lib/features/auth/reset_password_view.dart
+++ b/lib/features/auth/reset_password_view.dart
@@ -20,6 +20,7 @@ class ResetPasswordView extends ConsumerWidget {
         title: const Text('Reset Password'),
       ),
       body: SingleChildScrollView(
+        reverse: true,
         child: Padding(
           padding: const EdgeInsets.all(25.0),
           child: Form(


### PR DESCRIPTION
This fixes the keyboard covering the buttons by setting the scroll position to the bottom of the screen when the keyboard is open.

The user will no longer need to scroll or close the keyboard to press the button.

Closes #104