### PR TITLE
Improve Firebase Call Times

### DIFF
--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -457,23 +457,27 @@ class FirebaseController {
       }
 
       // Create a new series with the title with the first item in the list
-      final newSeries = await addSeries(
+      final newSeriesFuture = addSeries(
         name: name ?? selectedBooks.first.title,
         imageUrl: selectedBooks.first.imageUrl ?? kDefaultImage,
         collectionIds: collectionIds,
       );
 
-      await addBooksToSeries(
-        books: selectedBooks,
-        series: newSeries,
-        collectionIds: collectionIds,
-      );
+      // ignore: unawaited_futures
+      newSeriesFuture.then((newSeries) {
+        addBooksToSeries(
+          books: selectedBooks,
+          series: newSeries,
+          collectionIds: collectionIds,
+        );
+      });
 
       for (final series in selectedSeries) {
-        await _firebaseService.deleteSeriesDocument(series.id);
+        // ignore: unawaited_futures
+        _firebaseService.deleteSeriesDocument(series.id);
       }
 
-      return newSeries;
+      return newSeriesFuture;
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -498,7 +498,8 @@ class FirebaseController {
   }) async {
     try {
       for (final book in books) {
-        await _firebaseService.addBookToSeries(
+        // ignore: unawaited_futures
+        _firebaseService.addBookToSeries(
           bookId: book.id,
           seriesId: series.id,
           collectionIds: collectionIds,

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -527,7 +527,7 @@ class FirebaseController {
     Set<String>? collectionIds,
   }) async {
     try {
-      return await _firebaseService.addSeries(
+      return _firebaseService.addSeries(
         name,
         imageUrl: imageUrl,
         description: description,

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -470,12 +470,12 @@ class FirebaseController {
           series: newSeries,
           collectionIds: collectionIds,
         );
+        
+        for (final series in selectedSeries) {
+          // ignore: unawaited_futures
+          _firebaseService.deleteSeriesDocument(series.id);
+        }
       });
-
-      for (final series in selectedSeries) {
-        // ignore: unawaited_futures
-        _firebaseService.deleteSeriesDocument(series.id);
-      }
 
       return newSeriesFuture;
     } on FirebaseException catch (e) {

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -626,19 +626,15 @@ class FirebaseController {
         // Delete all books in the series
         final seriesItems = _getSeriesItems(item, allBooks);
         for (final itemInSeries in seriesItems) {
-          if (itemInSeries is Book) {
-            await _firebaseService.deleteBookDocument(itemInSeries.id);
-            deletedBooks.add(itemInSeries);
-          }
+          await _firebaseService.deleteBookDocument(itemInSeries.id);
+          deletedBooks.add(itemInSeries);
         }
 
         // Delete the series document in firebase
         await _firebaseService.deleteSeriesDocument(item.id);
 
         for (final itemInSeries in seriesItems) {
-          if (itemInSeries is Book) {
-            await _deleteFirebaseStorageBookFiles(itemInSeries.filepath);
-          }
+          await _deleteFirebaseStorageBookFiles(itemInSeries.filepath);
         }
       }
     }

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -673,10 +673,13 @@ class FirebaseController {
     required List<Book> books,
   }) async {
     try {
-      await _firebaseService.deleteSeriesDocument(series.id);
+      // ignore: unawaited_futures
+      _firebaseService.deleteSeriesDocument(series.id);
       for (final book in books) {
-        await _firebaseService.updateBookSeries(book.id, null);
-        await _firebaseService.updateBookCollections(
+        // ignore: unawaited_futures
+        _firebaseService.updateBookSeries(book.id, null);
+        // ignore: unawaited_futures
+        _firebaseService.updateBookCollections(
           bookId: book.id,
           collectionIds: series.collectionIds.toList(),
         );

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -552,11 +552,12 @@ class FirebaseController {
     required Book book,
     required Series series,
   }) async {
-    final collectionIds = series.collectionIds;
+    final Set<String> collectionIds = series.collectionIds;
     collectionIds.addAll(book.collectionIds);
 
     try {
-      await _firebaseService.addBookToSeries(
+      // ignore: unawaited_futures
+      _firebaseService.addBookToSeries(
         bookId: book.id,
         seriesId: series.id,
         collectionIds: collectionIds,

--- a/lib/controller/firebase_controller.dart
+++ b/lib/controller/firebase_controller.dart
@@ -409,7 +409,7 @@ class FirebaseController {
   /// Create a collection
   Future<Either<Failure, AppCollection>> addCollection(String name) async {
     // Create collection document
-    return await _firebaseService.addCollection(name);
+    return _firebaseService.addCollection(name);
   }
 
   /// Add a list of books to a collection
@@ -422,12 +422,14 @@ class FirebaseController {
     try {
       for (final item in items) {
         if (item is Book) {
-          await _firebaseService.updateBookCollections(
+          // ignore: unawaited_futures
+          _firebaseService.updateBookCollections(
             bookId: item.id,
             collectionIds: collectionIds,
           );
         } else if (item is Series) {
-          await _firebaseService.updateSeriesCollections(
+          // ignore: unawaited_futures
+          _firebaseService.updateSeriesCollections(
             seriesId: item.id,
             collectionIds: collectionIds,
           );
@@ -470,7 +472,7 @@ class FirebaseController {
           series: newSeries,
           collectionIds: collectionIds,
         );
-        
+
         for (final series in selectedSeries) {
           // ignore: unawaited_futures
           _firebaseService.deleteSeriesDocument(series.id);

--- a/lib/features/profile/profile_view.dart
+++ b/lib/features/profile/profile_view.dart
@@ -5,7 +5,6 @@ import 'package:book_adapter/features/profile/edit_profile_view.dart';
 import 'package:book_adapter/features/profile/widgets/change_password_button.dart';
 import 'package:book_adapter/features/profile/widgets/log_out_button.dart';
 import 'package:book_adapter/features/profile/widgets/profile_widget.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info/package_info.dart';

--- a/lib/model/queue_model.dart
+++ b/lib/model/queue_model.dart
@@ -12,7 +12,10 @@ import 'package:logger/logger.dart';
 final queueBookProvider = StateNotifierProvider.autoDispose<QueueNotifier<Book>,
     QueueNotifierData<Book>>((ref) {
   final storageController = ref.read(storageControllerProvider);
-  final data = QueueNotifierData<Book>(queueListItems: [], queue: Queue());
+  final data = QueueNotifierData<Book>(
+    queueListItems: [],
+    queue: Queue(),
+  );
 
   return QueueNotifier<Book>(
     data: data,
@@ -33,8 +36,10 @@ final queueBookProvider = StateNotifierProvider.autoDispose<QueueNotifier<Book>,
 /// such as downloading a file and saving it to the device.
 class QueueNotifier<T extends Item>
     extends StateNotifier<QueueNotifierData<T>> {
-  QueueNotifier({required QueueNotifierData<T> data, required this.processItem})
-      : super(data);
+  QueueNotifier({
+    required QueueNotifierData<T> data,
+    required this.processItem,
+  }) : super(data);
 
   bool processing = false;
   final log = Logger();

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -230,7 +230,9 @@ class FirebaseService
             getDefaultCollectionName(currentUserUid!);
         collectionIds.add(defaultCollection);
       }
-      await _booksRef.doc(bookId).update({'collectionIds': collectionIds});
+
+      // ignore: unawaited_futures
+      return _booksRef.doc(bookId).update({'collectionIds': collectionIds});
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {
@@ -276,12 +278,8 @@ class FirebaseService
   ///
   /// Throws AppException if the book does not exist in Firestore
   Future<void> updateBookSeries(String bookId, String? seriesId) async {
-    final bookDocumentSnaphot = await _booksRef.doc(bookId).get();
-    if (!bookDocumentSnaphot.exists) {
-      throw AppException(bookId + 'does not exist');
-    }
-
-    await _booksRef.doc(bookId).update({'seriesId': seriesId});
+    // ignore: unawaited_futures
+    return _booksRef.doc(bookId).update({'seriesId': seriesId});
   }
 
   // Series *********************************************
@@ -355,7 +353,8 @@ class FirebaseService
   /// path is the firestore path to the document, ie `collection/document/collection/...`
   Future<void> deleteCollectionDocument(String collectionId) async {
     try {
-      await deleteDocument('$kCollectionsCollectionName/$collectionId');
+      // ignore: unawaited_futures
+      deleteDocument('$kCollectionsCollectionName/$collectionId');
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {
@@ -371,7 +370,8 @@ class FirebaseService
   /// path is the firestore path to the document, ie `collection/document/collection/...`
   Future<void> deleteBookDocument(String bookId) async {
     try {
-      await deleteDocument('$kBooksCollectionName/$bookId');
+      // ignore: unawaited_futures
+      deleteDocument('$kBooksCollectionName/$bookId');
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {
@@ -388,7 +388,7 @@ class FirebaseService
   Future<void> deleteSeriesDocument(String seriesId) async {
     try {
       // ignore: unawaited_futures
-      deleteDocument('$kSeriesCollectionName/$seriesId');
+      return deleteDocument('$kSeriesCollectionName/$seriesId');
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {
@@ -404,7 +404,8 @@ class FirebaseService
   /// path is the firestore path to the document, ie `collection/document/collection/...`
   Future<void> deleteDocument(String path) async {
     try {
-      await _firestore.doc(path).delete();
+      // ignore: unawaited_futures
+      return _firestore.doc(path).delete();
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -332,7 +332,7 @@ class FirebaseService
   }) async {
     try {
       // ignore: unawaited_futures
-      _booksRef.doc(bookId).update(
+      return _booksRef.doc(bookId).update(
         {
           'seriesId': seriesId,
           'collectionIds': collectionIds.toList(),
@@ -354,7 +354,7 @@ class FirebaseService
   Future<void> deleteCollectionDocument(String collectionId) async {
     try {
       // ignore: unawaited_futures
-      deleteDocument('$kCollectionsCollectionName/$collectionId');
+      return deleteDocument('$kCollectionsCollectionName/$collectionId');
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {
@@ -371,7 +371,7 @@ class FirebaseService
   Future<void> deleteBookDocument(String bookId) async {
     try {
       // ignore: unawaited_futures
-      deleteDocument('$kBooksCollectionName/$bookId');
+      return deleteDocument('$kBooksCollectionName/$bookId');
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -263,7 +263,7 @@ class FirebaseService
             getDefaultCollectionName(currentUserUid!);
         collectionIds.add(defaultCollection);
       }
-      
+
       return _seriesRef.doc(seriesId).update({'collectionIds': collectionIds});
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
@@ -301,15 +301,15 @@ class FirebaseService
       }
 
       // Create a shelf with a custom id so that it can easily be referenced later
-      final String id = uuid.v4();
       final series = Series(
-          id: id,
+          id: uuid.v4(),
           userId: userId,
           title: name,
           description: description,
           imageUrl: imageUrl,
           collectionIds: collectionIds ?? {'$userId-Default'});
-      await _seriesRef.doc(id).set(series);
+      // ignore: unawaited_futures
+      _seriesRef.doc(series.id).set(series);
 
       // Return the shelf to the caller in case they care
       return series;

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -333,7 +333,8 @@ class FirebaseService
     required Set<String> collectionIds,
   }) async {
     try {
-      await _booksRef.doc(bookId).update(
+      // ignore: unawaited_futures
+      _booksRef.doc(bookId).update(
         {
           'seriesId': seriesId,
           'collectionIds': collectionIds.toList(),
@@ -386,7 +387,8 @@ class FirebaseService
   /// path is the firestore path to the document, ie `collection/document/collection/...`
   Future<void> deleteSeriesDocument(String seriesId) async {
     try {
-      await deleteDocument('$kSeriesCollectionName/$seriesId');
+      // ignore: unawaited_futures
+      deleteDocument('$kSeriesCollectionName/$seriesId');
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -10,8 +10,6 @@ import 'package:book_adapter/service/firebase_service_auth_mixin.dart';
 import 'package:book_adapter/service/firebase_service_storage_mixin.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:dartz/dartz.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_storage/firebase_storage.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:uuid/uuid.dart';
 

--- a/lib/service/firebase_service.dart
+++ b/lib/service/firebase_service.dart
@@ -199,7 +199,8 @@ class FirebaseService
         name: collectionName,
         userId: userId,
       );
-      await _collectionsRef.doc(bookCollection.id).set(bookCollection);
+      // ignore: unawaited_futures
+      _collectionsRef.doc(bookCollection.id).set(bookCollection);
 
       // Return the shelf to the caller in case they care
       return Right(bookCollection);
@@ -231,7 +232,6 @@ class FirebaseService
         collectionIds.add(defaultCollection);
       }
 
-      // ignore: unawaited_futures
       return _booksRef.doc(bookId).update({'collectionIds': collectionIds});
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
@@ -263,7 +263,8 @@ class FirebaseService
             getDefaultCollectionName(currentUserUid!);
         collectionIds.add(defaultCollection);
       }
-      await _seriesRef.doc(seriesId).update({'collectionIds': collectionIds});
+      
+      return _seriesRef.doc(seriesId).update({'collectionIds': collectionIds});
     } on FirebaseException catch (e) {
       throw AppException(e.message ?? e.toString(), e.code);
     } on Exception catch (e) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -744,7 +744,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -912,7 +912,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -933,7 +933,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   provider:
     dependency: transitive
     description:
@@ -1197,21 +1197,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.10"
+    version: "1.17.12"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.2"
   time:
     dependency: transitive
     description:
@@ -1302,7 +1302,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   video_player:
     dependency: transitive
     description:
@@ -1330,7 +1330,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.1"
+    version: "7.3.0"
   wakelock:
     dependency: transitive
     description:
@@ -1451,5 +1451,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -23,7 +23,7 @@ packages:
     source: hosted
     version: "1.1.0"
   archive:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.4.2+9
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependency_overrides:
   archive: ^3.1.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,9 +6,6 @@ version: 0.4.2+9
 environment:
   sdk: ">=2.15.0 <3.0.0"
 
-dependency_overrides:
-  archive: ^3.1.6
-
 dependencies:
   cached_network_image: ^3.1.0
   cloud_firestore: ^3.1.0

--- a/test/mock_firebase_service.dart
+++ b/test/mock_firebase_service.dart
@@ -10,7 +10,6 @@ import 'package:dartz/dartz.dart';
 import 'package:epubx/epubx.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 


### PR DESCRIPTION
The app no longer awaits Firebase Firestore calls since the changes are made to the cache immediately and don't need to be awaited. This allows for operations that take multiple Firebase calls to be completed much faster.

Closes #109